### PR TITLE
Add tests for ZTP client and bootstrap packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.38.3
 	github.com/prometheus/client_golang v1.18.0
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
 	go.uber.org/zap v1.26.0
 	golang.org/x/net v0.48.0
@@ -37,7 +38,6 @@ require (
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
@@ -49,4 +49,5 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/agent/bootstrap_test.go
+++ b/pkg/agent/bootstrap_test.go
@@ -1,0 +1,341 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestDefaultBootstrapConfig(t *testing.T) {
+	config := DefaultBootstrapConfig()
+
+	assert.Equal(t, "eth0", config.ZTPInterface)
+	assert.Equal(t, 30*time.Second, config.RetryInterval)
+	assert.Equal(t, 0, config.MaxRetries) // 0 = infinite
+	assert.Empty(t, config.NexusServerURL)
+	assert.False(t, config.ZTPEnabled)
+}
+
+func TestNewBootstrap(t *testing.T) {
+	logger := zap.NewNop()
+	config := DefaultBootstrapConfig()
+	config.NexusServerURL = "http://nexus.example.com:9000"
+
+	bootstrap := NewBootstrap(config, logger)
+
+	require.NotNil(t, bootstrap)
+	assert.Equal(t, config, bootstrap.config)
+	assert.NotNil(t, bootstrap.logger)
+	assert.NotNil(t, bootstrap.client)
+}
+
+func TestState_String(t *testing.T) {
+	tests := []struct {
+		state    State
+		expected string
+	}{
+		{StateBootstrap, "bootstrap"},
+		{StateConnected, "connected"},
+		{StatePartitioned, "partitioned"},
+		{StateRecovering, "recovering"},
+		{State(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.state.String())
+		})
+	}
+}
+
+func TestBootstrap_Register_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/devices/register", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req RegistrationRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.NotEmpty(t, req.Serial)
+
+		resp := RegistrationResponse{
+			Status:   "approved",
+			DeviceID: "olt-test-001",
+			Message:  "Device registered successfully",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+		RetryInterval:  100 * time.Millisecond,
+		MaxRetries:     3,
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	resp, err := bootstrap.Register(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "approved", resp.Status)
+	assert.Equal(t, "olt-test-001", resp.DeviceID)
+}
+
+func TestBootstrap_Register_Pending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := RegistrationResponse{
+			Status:  "pending",
+			Message: "Awaiting administrator approval",
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	resp, err := bootstrap.Register(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "pending", resp.Status)
+}
+
+func TestBootstrap_Register_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	resp, err := bootstrap.Register(ctx)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestBootstrap_RegisterWithRetry_MaxRetries(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("service unavailable"))
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+		RetryInterval:  10 * time.Millisecond,
+		MaxRetries:     3,
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	resp, err := bootstrap.RegisterWithRetry(ctx)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "max registration attempts")
+	assert.Equal(t, 3, attempts)
+}
+
+func TestBootstrap_RegisterWithRetry_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := RegistrationResponse{
+			Status:  "pending",
+			Message: "Awaiting approval",
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+		RetryInterval:  1 * time.Second,
+		MaxRetries:     0,
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	resp, err := bootstrap.RegisterWithRetry(ctx)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestBootstrap_RegisterWithRetry_Rejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := RegistrationResponse{
+			Status:  "rejected",
+			Message: "Device not authorized",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	config := BootstrapConfig{
+		NexusServerURL: server.URL,
+		SerialOverride: "TEST-SERIAL-001",
+		RetryInterval:  10 * time.Millisecond,
+		MaxRetries:     3,
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	resp, err := bootstrap.RegisterWithRetry(ctx)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "rejected")
+}
+
+func TestBootstrap_DiscoverNexusURL_ZTPDisabled(t *testing.T) {
+	logger := zap.NewNop()
+
+	config := BootstrapConfig{
+		ZTPEnabled:     false,
+		NexusServerURL: "http://configured.nexus.com:9000",
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	url, err := bootstrap.DiscoverNexusURL(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://configured.nexus.com:9000", url)
+}
+
+func TestBootstrap_DiscoverNexusURL_ZTPDisabledNoURL(t *testing.T) {
+	logger := zap.NewNop()
+
+	config := BootstrapConfig{
+		ZTPEnabled:     false,
+		NexusServerURL: "",
+	}
+
+	bootstrap := NewBootstrap(config, logger)
+
+	ctx := context.Background()
+	url, err := bootstrap.DiscoverNexusURL(ctx)
+
+	assert.Error(t, err)
+	assert.Empty(t, url)
+	assert.Contains(t, err.Error(), "ZTP not enabled")
+}
+
+func TestDeviceInfo_JSON(t *testing.T) {
+	info := DeviceInfo{
+		Serial:       "TEST-123",
+		MAC:          "aa:bb:cc:dd:ee:ff",
+		Model:        "TestOLT-1600",
+		Firmware:     "5.15.0",
+		AgentVersion: "1.0.0",
+		Capabilities: []string{"gpon", "10g-uplink", "ebpf"},
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var decoded DeviceInfo
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, info.Serial, decoded.Serial)
+	assert.Equal(t, info.MAC, decoded.MAC)
+	assert.Equal(t, info.Model, decoded.Model)
+	assert.Equal(t, info.Firmware, decoded.Firmware)
+	assert.Equal(t, info.Capabilities, decoded.Capabilities)
+}
+
+func TestRegistrationRequest_JSON(t *testing.T) {
+	req := RegistrationRequest{
+		DeviceInfo: DeviceInfo{
+			Serial:       "TEST-123",
+			MAC:          "aa:bb:cc:dd:ee:ff",
+			Model:        "TestOLT",
+			AgentVersion: "1.0.0",
+			Capabilities: []string{"ebpf"},
+		},
+		Timestamp: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var decoded RegistrationRequest
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, req.Serial, decoded.Serial)
+	assert.Equal(t, req.Timestamp.UTC(), decoded.Timestamp.UTC())
+}
+
+func TestRegistrationResponse_JSON(t *testing.T) {
+	resp := RegistrationResponse{
+		Status:     "approved",
+		DeviceID:   "olt-001",
+		CLSetPeers: []string{"peer1:9000", "peer2:9000"},
+		Message:    "Welcome",
+		Config: &DeviceConfig{
+			DeviceID: "olt-001",
+			NetCoID:  "netco-1",
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded RegistrationResponse
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "approved", decoded.Status)
+	assert.Equal(t, "olt-001", decoded.DeviceID)
+	assert.Len(t, decoded.CLSetPeers, 2)
+	require.NotNil(t, decoded.Config)
+	assert.Equal(t, "netco-1", decoded.Config.NetCoID)
+}

--- a/pkg/ztp/client_linux_test.go
+++ b/pkg/ztp/client_linux_test.go
@@ -1,0 +1,153 @@
+//go:build linux
+
+package ztp
+
+import (
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractNexusURL_Option224(t *testing.T) {
+	msg, err := dhcpv4.New()
+	require.NoError(t, err)
+
+	expectedURL := "http://nexus.example.com:9000"
+	msg.Options[224] = []byte(expectedURL)
+
+	result := extractNexusURL(msg)
+	assert.Equal(t, expectedURL, result)
+}
+
+func TestExtractNexusURL_VendorOption43(t *testing.T) {
+	msg, err := dhcpv4.New()
+	require.NoError(t, err)
+
+	// Vendor option 43 with TLV: Type=1, Length=len, Value=URL
+	url := "http://nexus.local:9000"
+	vendorData := []byte{0x01, byte(len(url))}
+	vendorData = append(vendorData, []byte(url)...)
+	msg.Options[43] = vendorData
+
+	result := extractNexusURL(msg)
+	assert.Equal(t, url, result)
+}
+
+func TestExtractNexusURL_Option224TakesPrecedence(t *testing.T) {
+	msg, err := dhcpv4.New()
+	require.NoError(t, err)
+
+	// Set both options - 224 should take precedence
+	option224URL := "http://option224.example.com:9000"
+	option43URL := "http://option43.example.com:9000"
+
+	msg.Options[224] = []byte(option224URL)
+	vendorData := []byte{0x01, byte(len(option43URL))}
+	vendorData = append(vendorData, []byte(option43URL)...)
+	msg.Options[43] = vendorData
+
+	result := extractNexusURL(msg)
+	assert.Equal(t, option224URL, result)
+}
+
+func TestExtractNexusURL_NoOptions(t *testing.T) {
+	msg, err := dhcpv4.New()
+	require.NoError(t, err)
+
+	result := extractNexusURL(msg)
+	assert.Empty(t, result)
+}
+
+func TestExtractNexusURL_EmptyOption224(t *testing.T) {
+	msg, err := dhcpv4.New()
+	require.NoError(t, err)
+
+	msg.Options[224] = []byte{}
+
+	result := extractNexusURL(msg)
+	assert.Empty(t, result)
+}
+
+func TestParseVendorOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected string
+	}{
+		{
+			name:     "valid nexus URL (type 1)",
+			data:     append([]byte{0x01, 0x11}, []byte("http://nexus:9000")...),
+			expected: "http://nexus:9000",
+		},
+		{
+			name:     "wrong type (type 2)",
+			data:     append([]byte{0x02, 0x05}, []byte("hello")...),
+			expected: "",
+		},
+		{
+			name: "multiple options with type 1 second",
+			data: func() []byte {
+				// Type 2, length 3, "foo"
+				d := []byte{0x02, 0x03, 'f', 'o', 'o'}
+				// Type 1, length 3, "bar"
+				d = append(d, 0x01, 0x03, 'b', 'a', 'r')
+				return d
+			}(),
+			expected: "bar",
+		},
+		{
+			name:     "truncated data - length exceeds available",
+			data:     []byte{0x01, 0x10, 'h', 't', 't', 'p'}, // length says 16 but only 4 bytes
+			expected: "",
+		},
+		{
+			name:     "empty data",
+			data:     []byte{},
+			expected: "",
+		},
+		{
+			name:     "single byte - no length field",
+			data:     []byte{0x01},
+			expected: "",
+		},
+		{
+			name:     "zero length value",
+			data:     []byte{0x01, 0x00},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseVendorOptions(tt.data)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMaskSize(t *testing.T) {
+	tests := []struct {
+		bits     int
+		expected int
+	}{
+		{24, 24},
+		{16, 16},
+		{32, 32},
+		{8, 8},
+		{0, 0},
+	}
+
+	for _, tt := range tests {
+		mask := make([]byte, 4)
+		for i := 0; i < tt.bits/8; i++ {
+			mask[i] = 0xff
+		}
+		if tt.bits%8 != 0 {
+			mask[tt.bits/8] = byte(0xff << (8 - tt.bits%8))
+		}
+		result := maskSize(mask)
+		assert.Equal(t, tt.expected, result)
+	}
+}

--- a/pkg/ztp/client_test.go
+++ b/pkg/ztp/client_test.go
@@ -1,0 +1,73 @@
+package ztp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name  string
+		iface string
+	}{
+		{name: "eth0 interface", iface: "eth0"},
+		{name: "mgmt0 interface", iface: "mgmt0"},
+		{name: "empty interface", iface: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(tt.iface)
+			require.NotNil(t, client)
+			assert.Equal(t, tt.iface, client.iface)
+		})
+	}
+}
+
+func TestResult_Fields(t *testing.T) {
+	result := Result{
+		IP:        net.ParseIP("10.0.0.100"),
+		Mask:      net.CIDRMask(24, 32),
+		Gateway:   net.ParseIP("10.0.0.1"),
+		DNS:       []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("8.8.4.4")},
+		NexusURL:  "http://nexus.example.com:9000",
+		LeaseTime: 24 * time.Hour,
+	}
+
+	assert.Equal(t, "10.0.0.100", result.IP.String())
+	assert.Equal(t, "ffffff00", result.Mask.String())
+	assert.Equal(t, "10.0.0.1", result.Gateway.String())
+	assert.Len(t, result.DNS, 2)
+	assert.Equal(t, "http://nexus.example.com:9000", result.NexusURL)
+	assert.Equal(t, 24*time.Hour, result.LeaseTime)
+}
+
+func TestResult_EmptyFields(t *testing.T) {
+	result := Result{}
+
+	assert.Nil(t, result.IP)
+	assert.Nil(t, result.Mask)
+	assert.Nil(t, result.Gateway)
+	assert.Nil(t, result.DNS)
+	assert.Empty(t, result.NexusURL)
+	assert.Zero(t, result.LeaseTime)
+}
+
+func TestResult_IPv6(t *testing.T) {
+	result := Result{
+		IP:        net.ParseIP("2001:db8::1"),
+		Mask:      net.CIDRMask(64, 128),
+		Gateway:   net.ParseIP("2001:db8::ffff"),
+		DNS:       []net.IP{net.ParseIP("2001:4860:4860::8888")},
+		NexusURL:  "http://[2001:db8::100]:9000",
+		LeaseTime: 12 * time.Hour,
+	}
+
+	assert.Equal(t, "2001:db8::1", result.IP.String())
+	assert.Len(t, result.DNS, 1)
+	assert.Contains(t, result.NexusURL, "2001:db8")
+}


### PR DESCRIPTION
## Summary
- Add cross-platform tests for `pkg/ztp` client and Result struct
- Add Linux-specific tests for DHCP option parsing (`extractNexusURL`, `parseVendorOptions`)
- Add comprehensive tests for `pkg/agent` Bootstrap registration flow

## Test Coverage
| Package | Tests | Coverage |
|---------|-------|----------|
| `pkg/ztp` | 4 cross-platform + 7 Linux-specific | `NewClient`, `Result` fields, `extractNexusURL`, `parseVendorOptions` |
| `pkg/agent` | 15 tests | `DefaultBootstrapConfig`, `NewBootstrap`, `State.String`, `Register`, `RegisterWithRetry`, `DiscoverNexusURL`, JSON serialization |

## Test Scenarios
- Registration success, pending, rejected
- Server errors (500)
- Retry logic with max retries
- Context cancellation
- ZTP disabled with/without configured URL

## Test plan
- [x] `go test ./pkg/ztp/...` passes
- [x] `go test ./pkg/agent/...` passes
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.ai/code)