### PR TITLE
feat(ebpf): re-implement Option 82 circuit-ID support (#56)

### DIFF
--- a/pkg/routing/manager_test.go
+++ b/pkg/routing/manager_test.go
@@ -10,10 +10,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// isPermissionError checks if an error is due to:
+// isEnvironmentError checks if an error is due to:
 // - missing network permissions (CAP_NET_ADMIN)
 // - missing network interfaces (common in CI environments)
-func isPermissionError(err error) bool {
+func isEnvironmentError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -24,6 +24,11 @@ func isPermissionError(err error) bool {
 		strings.Contains(errStr, "not permitted") ||
 		strings.Contains(errStr, "Link not found") ||
 		strings.Contains(errStr, "no such device")
+}
+
+// Alias for backward compatibility
+func isPermissionError(err error) bool {
+	return isEnvironmentError(err)
 }
 
 func TestLinkState_String(t *testing.T) {


### PR DESCRIPTION
## Summary

Re-implements Option 82 circuit-ID based subscriber lookup that was removed during eBPF verifier fixes (Issue #31). Uses a fixed-size key approach to avoid verifier issues with variable-length hashing loops.

### Changes
- Add `circuit_id_subscribers` BPF map with fixed 32-byte key
- Add `extract_circuit_id_fixed()` for verifier-safe Option 82 parsing
- Update lookup strategy: VLAN → Circuit-ID → MAC fallback
- Add `CircuitIDKey` type and subscriber map operations to loader
- Populate circuit-ID subscriber map in DHCP slow path
- Add comprehensive tests for `CircuitIDKey` functionality

### Design Decisions
- **Fixed positions checked**: Positions 3 and 12-19 where Option 82 commonly appears
- **32-byte fixed key**: Circuit-IDs padded/truncated for consistent map key size
- **Verifier-safe**: No loops or variable offsets in eBPF code
- **Kernel 5.15+ compatible**: No `bpf_loop()` dependency
- **Backward compatible**: Legacy `circuit_id_map` (hash-based) retained

### Files Changed
| File | Changes |
|------|---------|
| `bpf/maps.h` | Add `circuit_id_key` struct and `circuit_id_subscribers` map |
| `bpf/dhcp_fastpath.c` | Add `extract_circuit_id_fixed()`, update lookup strategy |
| `pkg/ebpf/loader.go` | Add `CircuitIDKey` type and map operations |
| `pkg/dhcp/server.go` | Populate circuit-ID subscriber map on slow path |
| `pkg/ebpf/loader_test.go` | Add tests for `CircuitIDKey` functionality |

## Test plan
- [x] Go tests pass (`go test ./pkg/ebpf/... ./pkg/dhcp/...`)
- [x] Go build succeeds (`go build ./...`)
- [x] eBPF compilation succeeds (tested in Docker)
- [ ] CI verifier test passes (requires Linux runner)
- [ ] Manual test with DHCP relay agent sending Option 82

Closes #56

🤖 Generated with [Claude Code](https://claude.ai/code)