### PR TITLE
feat: Implement HA P2P state synchronization

### DIFF
--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -61,6 +61,22 @@ type RegistrationResponse struct {
 	Config     *DeviceConfig `json:"config,omitempty"`
 	CLSetPeers []string      `json:"clset_peers,omitempty"`
 	Message    string        `json:"message,omitempty"`
+
+	// HA (High Availability) configuration
+	// When this device is part of an HA pair, these fields describe the HA setup.
+	HARole    string     `json:"ha_role,omitempty"`    // "active", "standby", or empty if not in HA pair
+	HAPartner *HAPartner `json:"ha_partner,omitempty"` // Partner device info (if in HA pair)
+}
+
+// HAPartner contains information about the HA partner device.
+// This is used for P2P state synchronization between active/standby BNGs.
+type HAPartner struct {
+	// NodeID is the partner's unique device identifier.
+	NodeID string `json:"node_id"`
+
+	// Endpoint is the partner's HA sync endpoint (e.g., "10.0.0.1:9000").
+	// The standby connects to this endpoint to receive state updates.
+	Endpoint string `json:"endpoint"`
 }
 
 // DeviceConfig contains the full configuration for this OLT device.

--- a/pkg/ha/protocol.go
+++ b/pkg/ha/protocol.go
@@ -1,0 +1,180 @@
+// Package ha implements high availability peer-to-peer state synchronization
+// between BNG HA pairs (active/standby).
+//
+// When two BNGs are paired for HA at a site:
+// - Active serves subscriber traffic
+// - Standby shadows active's session state
+// - On failover, standby has all state needed to take over
+package ha
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Role represents the HA role of a BNG node.
+type Role string
+
+const (
+	// RoleActive indicates this node is the active BNG serving traffic.
+	RoleActive Role = "active"
+	// RoleStandby indicates this node is the standby BNG shadowing state.
+	RoleStandby Role = "standby"
+	// RoleUnknown indicates the role has not been determined yet.
+	RoleUnknown Role = "unknown"
+)
+
+// PartnerInfo contains information about the HA partner node.
+type PartnerInfo struct {
+	// NodeID is the partner's unique identifier.
+	NodeID string `json:"node_id"`
+	// Endpoint is the partner's sync endpoint (e.g., "10.0.0.1:9000").
+	Endpoint string `json:"endpoint"`
+}
+
+// SyncMessageType represents the type of sync message.
+type SyncMessageType string
+
+const (
+	// SyncTypeFull indicates a full state sync (all sessions).
+	SyncTypeFull SyncMessageType = "full"
+	// SyncTypeAdd indicates a new session was added.
+	SyncTypeAdd SyncMessageType = "add"
+	// SyncTypeUpdate indicates a session was updated.
+	SyncTypeUpdate SyncMessageType = "update"
+	// SyncTypeDelete indicates a session was deleted.
+	SyncTypeDelete SyncMessageType = "delete"
+	// SyncTypeHeartbeat indicates a keepalive message.
+	SyncTypeHeartbeat SyncMessageType = "heartbeat"
+	// SyncTypeFullRequest indicates a request for full sync.
+	SyncTypeFullRequest SyncMessageType = "full_request"
+)
+
+// SyncMessage represents a state synchronization message between HA pairs.
+type SyncMessage struct {
+	// Type indicates what kind of sync operation this is.
+	Type SyncMessageType `json:"type"`
+
+	// Sessions contains the session state being synced.
+	// For full sync, this contains all sessions.
+	// For add/update, this contains the affected session(s).
+	// For delete, this contains session IDs only.
+	Sessions []SessionState `json:"sessions,omitempty"`
+
+	// Timestamp is when this message was generated.
+	Timestamp time.Time `json:"timestamp"`
+
+	// SequenceNum is used for ordering incremental updates.
+	SequenceNum uint64 `json:"sequence_num,omitempty"`
+
+	// NodeID identifies the sender.
+	NodeID string `json:"node_id"`
+}
+
+// SessionState represents the synchronizable state of a subscriber session.
+// This is the minimal state needed for the standby to take over.
+type SessionState struct {
+	// Identification
+	SessionID    string `json:"session_id"`
+	SubscriberID string `json:"subscriber_id"`
+	MAC          string `json:"mac"`
+
+	// Network assignment
+	IP      string `json:"ip"`
+	IPv6    string `json:"ipv6,omitempty"`
+	Gateway string `json:"gateway,omitempty"`
+	VLAN    int    `json:"vlan"`
+	STag    uint16 `json:"s_tag,omitempty"`
+	CTag    uint16 `json:"c_tag,omitempty"`
+
+	// Service configuration
+	QoSProfile      string `json:"qos_profile,omitempty"`
+	DownloadRateBps uint64 `json:"download_rate_bps,omitempty"`
+	UploadRateBps   uint64 `json:"upload_rate_bps,omitempty"`
+
+	// Session metadata
+	SessionType string `json:"session_type"` // "ipoe" or "pppoe"
+	ISPID       string `json:"isp_id,omitempty"`
+	Username    string `json:"username,omitempty"`
+
+	// Timing
+	CreatedAt    time.Time `json:"created_at"`
+	LastActivity time.Time `json:"last_activity"`
+
+	// State
+	State        string `json:"state"`
+	WalledGarden bool   `json:"walled_garden"`
+
+	// Statistics (optional, for monitoring)
+	BytesIn  uint64 `json:"bytes_in,omitempty"`
+	BytesOut uint64 `json:"bytes_out,omitempty"`
+}
+
+// SyncStats contains statistics about the sync process.
+type SyncStats struct {
+	// LastSyncTime is when we last successfully synced.
+	LastSyncTime time.Time `json:"last_sync_time"`
+
+	// SessionsSynced is the total number of sessions currently synced.
+	SessionsSynced int `json:"sessions_synced"`
+
+	// MessagesReceived is the total number of sync messages received.
+	MessagesReceived uint64 `json:"messages_received"`
+
+	// MessagesSent is the total number of sync messages sent.
+	MessagesSent uint64 `json:"messages_sent"`
+
+	// BytesReceived is the total bytes received.
+	BytesReceived uint64 `json:"bytes_received"`
+
+	// BytesSent is the total bytes sent.
+	BytesSent uint64 `json:"bytes_sent"`
+
+	// LastError is the last error encountered (if any).
+	LastError string `json:"last_error,omitempty"`
+
+	// LastErrorTime is when the last error occurred.
+	LastErrorTime time.Time `json:"last_error_time,omitempty"`
+
+	// Connected indicates whether we're connected to our partner.
+	Connected bool `json:"connected"`
+
+	// PartnerNodeID is the node ID of our partner (if connected).
+	PartnerNodeID string `json:"partner_node_id,omitempty"`
+}
+
+// Encode serializes a SyncMessage to JSON bytes.
+func (m *SyncMessage) Encode() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// DecodeSyncMessage deserializes a SyncMessage from JSON bytes.
+func DecodeSyncMessage(data []byte) (*SyncMessage, error) {
+	var m SyncMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// SessionStore is the interface for accessing session state.
+// This abstracts the underlying session storage mechanism.
+type SessionStore interface {
+	// GetSession returns a session by ID.
+	GetSession(sessionID string) (*SessionState, bool)
+
+	// GetAllSessions returns all active sessions.
+	GetAllSessions() []SessionState
+
+	// PutSession adds or updates a session.
+	PutSession(session *SessionState) error
+
+	// DeleteSession removes a session.
+	DeleteSession(sessionID string) error
+
+	// GetSessionCount returns the number of active sessions.
+	GetSessionCount() int
+}
+
+// ChangeNotifier is called when session state changes.
+type ChangeNotifier func(changeType SyncMessageType, session *SessionState)

--- a/pkg/ha/sync.go
+++ b/pkg/ha/sync.go
@@ -1,0 +1,697 @@
+package ha
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// SyncConfig contains configuration for the HA syncer.
+type SyncConfig struct {
+	// NodeID is this node's unique identifier.
+	NodeID string
+
+	// Role is this node's HA role (active or standby).
+	Role Role
+
+	// Partner contains information about the HA partner.
+	Partner *PartnerInfo
+
+	// ListenAddr is the address to listen on for incoming sync connections.
+	// Only used by active nodes.
+	ListenAddr string
+
+	// ReconnectInterval is how long to wait before reconnecting after disconnect.
+	ReconnectInterval time.Duration
+
+	// HeartbeatInterval is how often to send heartbeat messages.
+	HeartbeatInterval time.Duration
+
+	// FullSyncInterval is how often to request a full sync (standby only).
+	// Set to 0 to disable periodic full syncs.
+	FullSyncInterval time.Duration
+
+	// ConnectTimeout is the timeout for establishing connections.
+	ConnectTimeout time.Duration
+
+	// RequestTimeout is the timeout for HTTP requests.
+	RequestTimeout time.Duration
+}
+
+// DefaultSyncConfig returns sensible defaults for sync configuration.
+func DefaultSyncConfig() SyncConfig {
+	return SyncConfig{
+		ReconnectInterval: 5 * time.Second,
+		HeartbeatInterval: 10 * time.Second,
+		FullSyncInterval:  5 * time.Minute,
+		ConnectTimeout:    10 * time.Second,
+		RequestTimeout:    30 * time.Second,
+	}
+}
+
+// HASyncer manages state synchronization between HA pairs.
+type HASyncer struct {
+	config SyncConfig
+	logger *zap.Logger
+	store  SessionStore
+	client *http.Client
+	server *http.Server
+
+	// State
+	mu          sync.RWMutex
+	connected   bool
+	sequenceNum uint64
+	stats       SyncStats
+
+	// Change notifications from local session manager
+	pendingChanges chan *SyncMessage
+
+	// For standby: received state from active
+	receivedSessions map[string]*SessionState
+	receivedMu       sync.RWMutex
+
+	// SSE connections from standby nodes (active only)
+	sseClients   map[string]chan *SyncMessage
+	sseClientsMu sync.RWMutex
+
+	// Lifecycle
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewHASyncer creates a new HA syncer.
+func NewHASyncer(config SyncConfig, store SessionStore, logger *zap.Logger) *HASyncer {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &HASyncer{
+		config:           config,
+		logger:           logger,
+		store:            store,
+		client:           &http.Client{Timeout: config.RequestTimeout},
+		pendingChanges:   make(chan *SyncMessage, 1000),
+		receivedSessions: make(map[string]*SessionState),
+		sseClients:       make(map[string]chan *SyncMessage),
+		ctx:              ctx,
+		cancel:           cancel,
+	}
+}
+
+// Start begins the sync process.
+// For active nodes: starts the HTTP server for standby connections.
+// For standby nodes: connects to active and starts receiving updates.
+func (s *HASyncer) Start() error {
+	s.logger.Info("Starting HA syncer",
+		zap.String("node_id", s.config.NodeID),
+		zap.String("role", string(s.config.Role)),
+	)
+
+	switch s.config.Role {
+	case RoleActive:
+		return s.startActive()
+	case RoleStandby:
+		return s.startStandby()
+	default:
+		return fmt.Errorf("unknown role: %s", s.config.Role)
+	}
+}
+
+// Stop shuts down the syncer gracefully.
+func (s *HASyncer) Stop() error {
+	s.logger.Info("Stopping HA syncer")
+	s.cancel()
+
+	// Close SSE client channels
+	s.sseClientsMu.Lock()
+	for _, ch := range s.sseClients {
+		close(ch)
+	}
+	s.sseClients = make(map[string]chan *SyncMessage)
+	s.sseClientsMu.Unlock()
+
+	// Shutdown HTTP server if running
+	if s.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.server.Shutdown(ctx)
+	}
+
+	s.wg.Wait()
+	s.logger.Info("HA syncer stopped")
+	return nil
+}
+
+// ===== Active Node Implementation =====
+
+// startActive starts the HTTP server for standby nodes to connect.
+func (s *HASyncer) startActive() error {
+	if s.config.ListenAddr == "" {
+		s.config.ListenAddr = ":9000"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ha/sessions", s.handleGetSessions)
+	mux.HandleFunc("/ha/sessions/stream", s.handleSessionStream)
+	mux.HandleFunc("/ha/health", s.handleHealth)
+
+	s.server = &http.Server{
+		Addr:    s.config.ListenAddr,
+		Handler: mux,
+	}
+
+	// Start server in goroutine
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.logger.Info("Starting HA sync server", zap.String("addr", s.config.ListenAddr))
+		if err := s.server.ListenAndServe(); err != http.ErrServerClosed {
+			s.logger.Error("HA sync server error", zap.Error(err))
+		}
+	}()
+
+	// Start change broadcaster
+	s.wg.Add(1)
+	go s.broadcastLoop()
+
+	return nil
+}
+
+// handleGetSessions returns all sessions for full sync.
+// GET /ha/sessions
+func (s *HASyncer) handleGetSessions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessions := s.store.GetAllSessions()
+
+	msg := &SyncMessage{
+		Type:        SyncTypeFull,
+		Sessions:    sessions,
+		Timestamp:   time.Now(),
+		SequenceNum: atomic.LoadUint64(&s.sequenceNum),
+		NodeID:      s.config.NodeID,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(msg); err != nil {
+		s.logger.Error("Failed to encode sessions", zap.Error(err))
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	s.mu.Lock()
+	s.stats.MessagesSent++
+	s.mu.Unlock()
+
+	s.logger.Info("Sent full sync",
+		zap.Int("sessions", len(sessions)),
+		zap.String("client", r.RemoteAddr),
+	)
+}
+
+// handleSessionStream streams session updates via Server-Sent Events.
+// GET /ha/sessions/stream
+func (s *HASyncer) handleSessionStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Set up SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Create channel for this client
+	clientID := r.RemoteAddr
+	msgChan := make(chan *SyncMessage, 100)
+
+	s.sseClientsMu.Lock()
+	s.sseClients[clientID] = msgChan
+	s.sseClientsMu.Unlock()
+
+	s.logger.Info("SSE client connected", zap.String("client", clientID))
+
+	defer func() {
+		s.sseClientsMu.Lock()
+		delete(s.sseClients, clientID)
+		s.sseClientsMu.Unlock()
+		s.logger.Info("SSE client disconnected", zap.String("client", clientID))
+	}()
+
+	// Send initial heartbeat
+	s.sendSSE(w, flusher, &SyncMessage{
+		Type:      SyncTypeHeartbeat,
+		Timestamp: time.Now(),
+		NodeID:    s.config.NodeID,
+	})
+
+	// Stream updates
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-s.ctx.Done():
+			return
+		case msg, ok := <-msgChan:
+			if !ok {
+				return
+			}
+			s.sendSSE(w, flusher, msg)
+		}
+	}
+}
+
+// sendSSE sends a Server-Sent Event.
+func (s *HASyncer) sendSSE(w http.ResponseWriter, flusher http.Flusher, msg *SyncMessage) {
+	data, err := msg.Encode()
+	if err != nil {
+		s.logger.Error("Failed to encode SSE message", zap.Error(err))
+		return
+	}
+
+	fmt.Fprintf(w, "event: %s\n", msg.Type)
+	fmt.Fprintf(w, "data: %s\n\n", data)
+	flusher.Flush()
+
+	s.mu.Lock()
+	s.stats.MessagesSent++
+	s.stats.BytesSent += uint64(len(data))
+	s.mu.Unlock()
+}
+
+// handleHealth returns health status.
+// GET /ha/health
+func (s *HASyncer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	stats := s.stats
+	s.mu.RUnlock()
+
+	stats.SessionsSynced = s.store.GetSessionCount()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":  "healthy",
+		"role":    s.config.Role,
+		"node_id": s.config.NodeID,
+		"stats":   stats,
+	})
+}
+
+// broadcastLoop sends pending changes to all connected standby nodes.
+func (s *HASyncer) broadcastLoop() {
+	defer s.wg.Done()
+
+	heartbeatTicker := time.NewTicker(s.config.HeartbeatInterval)
+	defer heartbeatTicker.Stop()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+
+		case msg := <-s.pendingChanges:
+			s.broadcastToClients(msg)
+
+		case <-heartbeatTicker.C:
+			s.broadcastToClients(&SyncMessage{
+				Type:        SyncTypeHeartbeat,
+				Timestamp:   time.Now(),
+				SequenceNum: atomic.LoadUint64(&s.sequenceNum),
+				NodeID:      s.config.NodeID,
+			})
+		}
+	}
+}
+
+// broadcastToClients sends a message to all connected SSE clients.
+func (s *HASyncer) broadcastToClients(msg *SyncMessage) {
+	s.sseClientsMu.RLock()
+	defer s.sseClientsMu.RUnlock()
+
+	for clientID, ch := range s.sseClients {
+		select {
+		case ch <- msg:
+		default:
+			s.logger.Warn("Client channel full, dropping message",
+				zap.String("client", clientID),
+			)
+		}
+	}
+}
+
+// PushChange queues a session change to be pushed to standby nodes.
+// Called by the active node's session manager when state changes.
+func (s *HASyncer) PushChange(changeType SyncMessageType, session *SessionState) error {
+	if s.config.Role != RoleActive {
+		return fmt.Errorf("PushChange can only be called on active node")
+	}
+
+	seq := atomic.AddUint64(&s.sequenceNum, 1)
+
+	msg := &SyncMessage{
+		Type:        changeType,
+		Sessions:    []SessionState{*session},
+		Timestamp:   time.Now(),
+		SequenceNum: seq,
+		NodeID:      s.config.NodeID,
+	}
+
+	select {
+	case s.pendingChanges <- msg:
+		return nil
+	default:
+		return fmt.Errorf("change queue full")
+	}
+}
+
+// ===== Standby Node Implementation =====
+
+// startStandby connects to the active node and starts receiving updates.
+func (s *HASyncer) startStandby() error {
+	if s.config.Partner == nil {
+		return fmt.Errorf("partner info required for standby mode")
+	}
+
+	// Start the connection manager
+	s.wg.Add(1)
+	go s.standbyLoop()
+
+	return nil
+}
+
+// standbyLoop manages the connection to the active node.
+func (s *HASyncer) standbyLoop() {
+	defer s.wg.Done()
+
+	fullSyncTicker := time.NewTicker(s.config.FullSyncInterval)
+	if s.config.FullSyncInterval == 0 {
+		fullSyncTicker.Stop()
+	}
+	defer fullSyncTicker.Stop()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		default:
+		}
+
+		// Perform initial full sync
+		if err := s.performFullSync(); err != nil {
+			s.logger.Error("Full sync failed", zap.Error(err))
+			s.recordError(err)
+			s.waitReconnect()
+			continue
+		}
+
+		// Connect to SSE stream
+		if err := s.connectToStream(); err != nil {
+			s.logger.Error("Stream connection failed", zap.Error(err))
+			s.recordError(err)
+			s.waitReconnect()
+			continue
+		}
+	}
+}
+
+// performFullSync requests all sessions from the active node.
+func (s *HASyncer) performFullSync() error {
+	url := fmt.Sprintf("http://%s/ha/sessions", s.config.Partner.Endpoint)
+
+	ctx, cancel := context.WithTimeout(s.ctx, s.config.RequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var msg SyncMessage
+	if err := json.NewDecoder(resp.Body).Decode(&msg); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	// Apply full sync
+	s.receivedMu.Lock()
+	s.receivedSessions = make(map[string]*SessionState)
+	for i := range msg.Sessions {
+		session := msg.Sessions[i]
+		s.receivedSessions[session.SessionID] = &session
+		if err := s.store.PutSession(&session); err != nil {
+			s.logger.Warn("Failed to store session",
+				zap.String("session_id", session.SessionID),
+				zap.Error(err),
+			)
+		}
+	}
+	s.receivedMu.Unlock()
+
+	s.mu.Lock()
+	s.stats.LastSyncTime = time.Now()
+	s.stats.SessionsSynced = len(msg.Sessions)
+	s.stats.MessagesReceived++
+	s.stats.PartnerNodeID = msg.NodeID
+	s.mu.Unlock()
+
+	s.logger.Info("Full sync completed",
+		zap.Int("sessions", len(msg.Sessions)),
+		zap.Uint64("sequence", msg.SequenceNum),
+	)
+
+	return nil
+}
+
+// connectToStream connects to the SSE stream from the active node.
+func (s *HASyncer) connectToStream() error {
+	url := fmt.Sprintf("http://%s/ha/sessions/stream", s.config.Partner.Endpoint)
+
+	req, err := http.NewRequestWithContext(s.ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	s.mu.Lock()
+	s.connected = true
+	s.stats.Connected = true
+	s.mu.Unlock()
+
+	s.logger.Info("Connected to active node SSE stream",
+		zap.String("partner", s.config.Partner.Endpoint),
+	)
+
+	defer func() {
+		s.mu.Lock()
+		s.connected = false
+		s.stats.Connected = false
+		s.mu.Unlock()
+	}()
+
+	// Read SSE events
+	reader := bufio.NewReader(resp.Body)
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		default:
+		}
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF || isConnectionClosed(err) {
+				return fmt.Errorf("connection closed")
+			}
+			return fmt.Errorf("read error: %w", err)
+		}
+
+		// Parse SSE format
+		if bytes.HasPrefix([]byte(line), []byte("data: ")) {
+			data := line[6 : len(line)-1] // Remove "data: " prefix and trailing newline
+			if err := s.handleSSEData([]byte(data)); err != nil {
+				s.logger.Warn("Failed to handle SSE data", zap.Error(err))
+			}
+		}
+	}
+}
+
+// handleSSEData processes an incoming SSE data payload.
+func (s *HASyncer) handleSSEData(data []byte) error {
+	msg, err := DecodeSyncMessage(data)
+	if err != nil {
+		return fmt.Errorf("decode message: %w", err)
+	}
+
+	s.mu.Lock()
+	s.stats.MessagesReceived++
+	s.stats.BytesReceived += uint64(len(data))
+	s.mu.Unlock()
+
+	switch msg.Type {
+	case SyncTypeHeartbeat:
+		// Just update stats
+		s.logger.Debug("Received heartbeat", zap.String("from", msg.NodeID))
+
+	case SyncTypeAdd, SyncTypeUpdate:
+		for i := range msg.Sessions {
+			session := msg.Sessions[i]
+			s.receivedMu.Lock()
+			s.receivedSessions[session.SessionID] = &session
+			s.receivedMu.Unlock()
+
+			if err := s.store.PutSession(&session); err != nil {
+				s.logger.Warn("Failed to store session",
+					zap.String("session_id", session.SessionID),
+					zap.Error(err),
+				)
+			}
+
+			s.logger.Debug("Session synced",
+				zap.String("type", string(msg.Type)),
+				zap.String("session_id", session.SessionID),
+				zap.String("mac", session.MAC),
+				zap.String("ip", session.IP),
+			)
+		}
+
+	case SyncTypeDelete:
+		for i := range msg.Sessions {
+			session := msg.Sessions[i]
+			s.receivedMu.Lock()
+			delete(s.receivedSessions, session.SessionID)
+			s.receivedMu.Unlock()
+
+			if err := s.store.DeleteSession(session.SessionID); err != nil {
+				s.logger.Warn("Failed to delete session",
+					zap.String("session_id", session.SessionID),
+					zap.Error(err),
+				)
+			}
+
+			s.logger.Debug("Session deleted",
+				zap.String("session_id", session.SessionID),
+			)
+		}
+
+	case SyncTypeFull:
+		// Unexpected in stream, but handle gracefully
+		s.receivedMu.Lock()
+		s.receivedSessions = make(map[string]*SessionState)
+		for i := range msg.Sessions {
+			session := msg.Sessions[i]
+			s.receivedSessions[session.SessionID] = &session
+			s.store.PutSession(&session)
+		}
+		s.receivedMu.Unlock()
+	}
+
+	s.mu.Lock()
+	s.stats.SessionsSynced = len(s.receivedSessions)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// waitReconnect waits for the reconnect interval.
+func (s *HASyncer) waitReconnect() {
+	select {
+	case <-s.ctx.Done():
+	case <-time.After(s.config.ReconnectInterval):
+	}
+}
+
+// recordError records an error in stats.
+func (s *HASyncer) recordError(err error) {
+	s.mu.Lock()
+	s.stats.LastError = err.Error()
+	s.stats.LastErrorTime = time.Now()
+	s.mu.Unlock()
+}
+
+// ===== Public API =====
+
+// Stats returns current sync statistics.
+func (s *HASyncer) Stats() SyncStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	stats := s.stats
+	stats.SessionsSynced = s.store.GetSessionCount()
+	return stats
+}
+
+// IsConnected returns true if connected to partner.
+func (s *HASyncer) IsConnected() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.connected
+}
+
+// GetReceivedSession returns a session received from the active node (standby only).
+func (s *HASyncer) GetReceivedSession(sessionID string) (*SessionState, bool) {
+	s.receivedMu.RLock()
+	defer s.receivedMu.RUnlock()
+	session, ok := s.receivedSessions[sessionID]
+	return session, ok
+}
+
+// GetAllReceivedSessions returns all sessions received from active (standby only).
+func (s *HASyncer) GetAllReceivedSessions() []*SessionState {
+	s.receivedMu.RLock()
+	defer s.receivedMu.RUnlock()
+	sessions := make([]*SessionState, 0, len(s.receivedSessions))
+	for _, session := range s.receivedSessions {
+		sessions = append(sessions, session)
+	}
+	return sessions
+}
+
+// isConnectionClosed checks if the error indicates a closed connection.
+func isConnectionClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if netErr, ok := err.(*net.OpError); ok {
+		return netErr.Err.Error() == "use of closed network connection"
+	}
+	return false
+}

--- a/pkg/ha/sync_test.go
+++ b/pkg/ha/sync_test.go
@@ -1,0 +1,900 @@
+package ha
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// mockSessionStore implements SessionStore for testing.
+type mockSessionStore struct {
+	mu       sync.RWMutex
+	sessions map[string]*SessionState
+}
+
+func newMockSessionStore() *mockSessionStore {
+	return &mockSessionStore{
+		sessions: make(map[string]*SessionState),
+	}
+}
+
+func (m *mockSessionStore) GetSession(sessionID string) (*SessionState, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	s, ok := m.sessions[sessionID]
+	return s, ok
+}
+
+func (m *mockSessionStore) GetAllSessions() []SessionState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]SessionState, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		result = append(result, *s)
+	}
+	return result
+}
+
+func (m *mockSessionStore) PutSession(session *SessionState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[session.SessionID] = session
+	return nil
+}
+
+func (m *mockSessionStore) DeleteSession(sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, sessionID)
+	return nil
+}
+
+func (m *mockSessionStore) GetSessionCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sessions)
+}
+
+func TestSyncMessage_Encode_Decode(t *testing.T) {
+	original := &SyncMessage{
+		Type: SyncTypeAdd,
+		Sessions: []SessionState{
+			{
+				SessionID:    "sess-001",
+				SubscriberID: "sub-001",
+				MAC:          "00:11:22:33:44:55",
+				IP:           "10.0.0.100",
+				VLAN:         100,
+				QoSProfile:   "premium",
+				CreatedAt:    time.Now().Truncate(time.Second),
+			},
+		},
+		Timestamp:   time.Now().Truncate(time.Second),
+		SequenceNum: 42,
+		NodeID:      "bng-001",
+	}
+
+	// Encode
+	data, err := original.Encode()
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	// Decode
+	decoded, err := DecodeSyncMessage(data)
+	if err != nil {
+		t.Fatalf("DecodeSyncMessage() error = %v", err)
+	}
+
+	// Verify
+	if decoded.Type != original.Type {
+		t.Errorf("Type = %v, want %v", decoded.Type, original.Type)
+	}
+	if decoded.SequenceNum != original.SequenceNum {
+		t.Errorf("SequenceNum = %v, want %v", decoded.SequenceNum, original.SequenceNum)
+	}
+	if decoded.NodeID != original.NodeID {
+		t.Errorf("NodeID = %v, want %v", decoded.NodeID, original.NodeID)
+	}
+	if len(decoded.Sessions) != 1 {
+		t.Fatalf("len(Sessions) = %v, want 1", len(decoded.Sessions))
+	}
+	if decoded.Sessions[0].SessionID != original.Sessions[0].SessionID {
+		t.Errorf("SessionID = %v, want %v", decoded.Sessions[0].SessionID, original.Sessions[0].SessionID)
+	}
+}
+
+func TestHASyncer_ActiveHandleGetSessions(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	// Add some test sessions
+	store.PutSession(&SessionState{
+		SessionID:    "sess-001",
+		SubscriberID: "sub-001",
+		MAC:          "00:11:22:33:44:55",
+		IP:           "10.0.0.100",
+		VLAN:         100,
+		CreatedAt:    time.Now(),
+	})
+	store.PutSession(&SessionState{
+		SessionID:    "sess-002",
+		SubscriberID: "sub-002",
+		MAC:          "00:11:22:33:44:66",
+		IP:           "10.0.0.101",
+		VLAN:         100,
+		CreatedAt:    time.Now(),
+	})
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/ha/sessions", nil)
+	w := httptest.NewRecorder()
+
+	syncer.handleGetSessions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Status = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	var msg SyncMessage
+	if err := json.NewDecoder(resp.Body).Decode(&msg); err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+
+	if msg.Type != SyncTypeFull {
+		t.Errorf("Type = %v, want %v", msg.Type, SyncTypeFull)
+	}
+	if len(msg.Sessions) != 2 {
+		t.Errorf("len(Sessions) = %v, want 2", len(msg.Sessions))
+	}
+	if msg.NodeID != "bng-active" {
+		t.Errorf("NodeID = %v, want bng-active", msg.NodeID)
+	}
+}
+
+func TestHASyncer_ActiveHandleHealth(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	req := httptest.NewRequest("GET", "/ha/health", nil)
+	w := httptest.NewRecorder()
+
+	syncer.handleHealth(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Status = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	var health map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+
+	if health["status"] != "healthy" {
+		t.Errorf("status = %v, want healthy", health["status"])
+	}
+	if health["node_id"] != "bng-active" {
+		t.Errorf("node_id = %v, want bng-active", health["node_id"])
+	}
+}
+
+func TestHASyncer_PushChange(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	session := &SessionState{
+		SessionID:    "sess-001",
+		SubscriberID: "sub-001",
+		MAC:          "00:11:22:33:44:55",
+		IP:           "10.0.0.100",
+	}
+
+	// Push a change
+	err := syncer.PushChange(SyncTypeAdd, session)
+	if err != nil {
+		t.Fatalf("PushChange() error = %v", err)
+	}
+
+	// Verify change is queued
+	select {
+	case msg := <-syncer.pendingChanges:
+		if msg.Type != SyncTypeAdd {
+			t.Errorf("Type = %v, want %v", msg.Type, SyncTypeAdd)
+		}
+		if len(msg.Sessions) != 1 {
+			t.Errorf("len(Sessions) = %v, want 1", len(msg.Sessions))
+		}
+		if msg.Sessions[0].SessionID != "sess-001" {
+			t.Errorf("SessionID = %v, want sess-001", msg.Sessions[0].SessionID)
+		}
+	default:
+		t.Error("Expected change to be queued")
+	}
+}
+
+func TestHASyncer_PushChange_StandbyError(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-standby"
+	config.Role = RoleStandby
+	config.Partner = &PartnerInfo{
+		NodeID:   "bng-active",
+		Endpoint: "127.0.0.1:9000",
+	}
+
+	syncer := NewHASyncer(config, store, logger)
+
+	session := &SessionState{
+		SessionID: "sess-001",
+	}
+
+	err := syncer.PushChange(SyncTypeAdd, session)
+	if err == nil {
+		t.Error("Expected error when calling PushChange on standby")
+	}
+}
+
+func TestHASyncer_Integration_FullSync(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	// Create active node
+	activeStore := newMockSessionStore()
+	activeStore.PutSession(&SessionState{
+		SessionID:       "sess-001",
+		SubscriberID:    "sub-001",
+		MAC:             "00:11:22:33:44:55",
+		IP:              "10.0.0.100",
+		VLAN:            100,
+		QoSProfile:      "premium",
+		DownloadRateBps: 100_000_000,
+		UploadRateBps:   50_000_000,
+		SessionType:     "ipoe",
+		CreatedAt:       time.Now(),
+		State:           "active",
+	})
+	activeStore.PutSession(&SessionState{
+		SessionID:       "sess-002",
+		SubscriberID:    "sub-002",
+		MAC:             "00:11:22:33:44:66",
+		IP:              "10.0.0.101",
+		VLAN:            100,
+		QoSProfile:      "basic",
+		DownloadRateBps: 50_000_000,
+		UploadRateBps:   25_000_000,
+		SessionType:     "ipoe",
+		CreatedAt:       time.Now(),
+		State:           "active",
+	})
+
+	activeConfig := DefaultSyncConfig()
+	activeConfig.NodeID = "bng-active"
+	activeConfig.Role = RoleActive
+	activeConfig.ListenAddr = "127.0.0.1:0" // Random port
+
+	activeSyncer := NewHASyncer(activeConfig, activeStore, logger)
+
+	if err := activeSyncer.Start(); err != nil {
+		t.Fatalf("Active Start() error = %v", err)
+	}
+	defer activeSyncer.Stop()
+
+	// Get the actual port
+	time.Sleep(100 * time.Millisecond) // Wait for server to start
+
+	// Create a test server that wraps the active syncer's handlers
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ha/sessions":
+			activeSyncer.handleGetSessions(w, r)
+		case "/ha/health":
+			activeSyncer.handleHealth(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	// Create standby node
+	standbyStore := newMockSessionStore()
+
+	standbyConfig := DefaultSyncConfig()
+	standbyConfig.NodeID = "bng-standby"
+	standbyConfig.Role = RoleStandby
+	standbyConfig.Partner = &PartnerInfo{
+		NodeID:   "bng-active",
+		Endpoint: ts.Listener.Addr().String(),
+	}
+	standbyConfig.ReconnectInterval = 100 * time.Millisecond
+
+	standbySyncer := NewHASyncer(standbyConfig, standbyStore, logger)
+
+	// Perform full sync
+	err := standbySyncer.performFullSync()
+	if err != nil {
+		t.Fatalf("performFullSync() error = %v", err)
+	}
+
+	// Verify sessions were synced
+	if standbyStore.GetSessionCount() != 2 {
+		t.Errorf("Standby session count = %v, want 2", standbyStore.GetSessionCount())
+	}
+
+	sess1, ok := standbyStore.GetSession("sess-001")
+	if !ok {
+		t.Error("Expected to find sess-001")
+	} else {
+		if sess1.MAC != "00:11:22:33:44:55" {
+			t.Errorf("sess-001 MAC = %v, want 00:11:22:33:44:55", sess1.MAC)
+		}
+		if sess1.IP != "10.0.0.100" {
+			t.Errorf("sess-001 IP = %v, want 10.0.0.100", sess1.IP)
+		}
+	}
+
+	sess2, ok := standbyStore.GetSession("sess-002")
+	if !ok {
+		t.Error("Expected to find sess-002")
+	} else {
+		if sess2.MAC != "00:11:22:33:44:66" {
+			t.Errorf("sess-002 MAC = %v, want 00:11:22:33:44:66", sess2.MAC)
+		}
+	}
+
+	// Verify stats
+	stats := standbySyncer.Stats()
+	if stats.SessionsSynced != 2 {
+		t.Errorf("SessionsSynced = %v, want 2", stats.SessionsSynced)
+	}
+	if stats.MessagesReceived != 1 {
+		t.Errorf("MessagesReceived = %v, want 1", stats.MessagesReceived)
+	}
+}
+
+func TestHASyncer_HandleSSEData(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-standby"
+	config.Role = RoleStandby
+	config.Partner = &PartnerInfo{
+		NodeID:   "bng-active",
+		Endpoint: "127.0.0.1:9000",
+	}
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Test add
+	addMsg := &SyncMessage{
+		Type: SyncTypeAdd,
+		Sessions: []SessionState{
+			{
+				SessionID: "sess-001",
+				MAC:       "00:11:22:33:44:55",
+				IP:        "10.0.0.100",
+			},
+		},
+		NodeID: "bng-active",
+	}
+	data, _ := addMsg.Encode()
+	if err := syncer.handleSSEData(data); err != nil {
+		t.Fatalf("handleSSEData(add) error = %v", err)
+	}
+
+	if store.GetSessionCount() != 1 {
+		t.Errorf("Session count = %v, want 1", store.GetSessionCount())
+	}
+
+	// Test update
+	updateMsg := &SyncMessage{
+		Type: SyncTypeUpdate,
+		Sessions: []SessionState{
+			{
+				SessionID: "sess-001",
+				MAC:       "00:11:22:33:44:55",
+				IP:        "10.0.0.200", // Changed IP
+			},
+		},
+		NodeID: "bng-active",
+	}
+	data, _ = updateMsg.Encode()
+	if err := syncer.handleSSEData(data); err != nil {
+		t.Fatalf("handleSSEData(update) error = %v", err)
+	}
+
+	sess, ok := store.GetSession("sess-001")
+	if !ok {
+		t.Fatal("Expected to find sess-001")
+	}
+	if sess.IP != "10.0.0.200" {
+		t.Errorf("IP = %v, want 10.0.0.200", sess.IP)
+	}
+
+	// Test delete
+	deleteMsg := &SyncMessage{
+		Type: SyncTypeDelete,
+		Sessions: []SessionState{
+			{SessionID: "sess-001"},
+		},
+		NodeID: "bng-active",
+	}
+	data, _ = deleteMsg.Encode()
+	if err := syncer.handleSSEData(data); err != nil {
+		t.Fatalf("handleSSEData(delete) error = %v", err)
+	}
+
+	if store.GetSessionCount() != 0 {
+		t.Errorf("Session count = %v, want 0", store.GetSessionCount())
+	}
+}
+
+func TestHASyncer_HandleSSEData_Heartbeat(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-standby"
+	config.Role = RoleStandby
+	config.Partner = &PartnerInfo{
+		NodeID:   "bng-active",
+		Endpoint: "127.0.0.1:9000",
+	}
+
+	syncer := NewHASyncer(config, store, logger)
+
+	heartbeatMsg := &SyncMessage{
+		Type:      SyncTypeHeartbeat,
+		Timestamp: time.Now(),
+		NodeID:    "bng-active",
+	}
+	data, _ := heartbeatMsg.Encode()
+
+	err := syncer.handleSSEData(data)
+	if err != nil {
+		t.Fatalf("handleSSEData(heartbeat) error = %v", err)
+	}
+
+	// Heartbeat should not affect session count
+	if store.GetSessionCount() != 0 {
+		t.Errorf("Session count = %v, want 0", store.GetSessionCount())
+	}
+
+	stats := syncer.Stats()
+	if stats.MessagesReceived != 1 {
+		t.Errorf("MessagesReceived = %v, want 1", stats.MessagesReceived)
+	}
+}
+
+func TestHASyncer_GetReceivedSessions(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-standby"
+	config.Role = RoleStandby
+	config.Partner = &PartnerInfo{
+		NodeID:   "bng-active",
+		Endpoint: "127.0.0.1:9000",
+	}
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Simulate receiving sessions
+	addMsg := &SyncMessage{
+		Type: SyncTypeAdd,
+		Sessions: []SessionState{
+			{SessionID: "sess-001", MAC: "00:11:22:33:44:55"},
+			{SessionID: "sess-002", MAC: "00:11:22:33:44:66"},
+		},
+		NodeID: "bng-active",
+	}
+	data, _ := addMsg.Encode()
+	syncer.handleSSEData(data)
+
+	// Test GetReceivedSession
+	sess, ok := syncer.GetReceivedSession("sess-001")
+	if !ok {
+		t.Error("Expected to find sess-001")
+	}
+	if sess.MAC != "00:11:22:33:44:55" {
+		t.Errorf("MAC = %v, want 00:11:22:33:44:55", sess.MAC)
+	}
+
+	_, ok = syncer.GetReceivedSession("sess-999")
+	if ok {
+		t.Error("Did not expect to find sess-999")
+	}
+
+	// Test GetAllReceivedSessions
+	allSessions := syncer.GetAllReceivedSessions()
+	if len(allSessions) != 2 {
+		t.Errorf("len(allSessions) = %v, want 2", len(allSessions))
+	}
+}
+
+func TestHASyncer_Stats(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-test"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	stats := syncer.Stats()
+	if stats.SessionsSynced != 0 {
+		t.Errorf("Initial SessionsSynced = %v, want 0", stats.SessionsSynced)
+	}
+	if stats.MessagesReceived != 0 {
+		t.Errorf("Initial MessagesReceived = %v, want 0", stats.MessagesReceived)
+	}
+
+	// Add a session to store
+	store.PutSession(&SessionState{SessionID: "sess-001"})
+
+	stats = syncer.Stats()
+	if stats.SessionsSynced != 1 {
+		t.Errorf("SessionsSynced = %v, want 1", stats.SessionsSynced)
+	}
+}
+
+func TestHASyncer_StartStop_Active(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+	config.ListenAddr = "127.0.0.1:0"
+	config.HeartbeatInterval = 50 * time.Millisecond
+
+	syncer := NewHASyncer(config, store, logger)
+
+	if err := syncer.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Give time for goroutines to start
+	time.Sleep(100 * time.Millisecond)
+
+	if err := syncer.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
+func TestHASyncer_StartStop_StandbyNoPartner(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-standby"
+	config.Role = RoleStandby
+	// No partner configured
+
+	syncer := NewHASyncer(config, store, logger)
+
+	err := syncer.Start()
+	if err == nil {
+		t.Error("Expected error when starting standby without partner")
+		syncer.Stop()
+	}
+}
+
+func TestDefaultSyncConfig(t *testing.T) {
+	config := DefaultSyncConfig()
+
+	if config.ReconnectInterval != 5*time.Second {
+		t.Errorf("ReconnectInterval = %v, want 5s", config.ReconnectInterval)
+	}
+	if config.HeartbeatInterval != 10*time.Second {
+		t.Errorf("HeartbeatInterval = %v, want 10s", config.HeartbeatInterval)
+	}
+	if config.FullSyncInterval != 5*time.Minute {
+		t.Errorf("FullSyncInterval = %v, want 5m", config.FullSyncInterval)
+	}
+	if config.ConnectTimeout != 10*time.Second {
+		t.Errorf("ConnectTimeout = %v, want 10s", config.ConnectTimeout)
+	}
+	if config.RequestTimeout != 30*time.Second {
+		t.Errorf("RequestTimeout = %v, want 30s", config.RequestTimeout)
+	}
+}
+
+func TestRole_Constants(t *testing.T) {
+	if RoleActive != "active" {
+		t.Errorf("RoleActive = %v, want active", RoleActive)
+	}
+	if RoleStandby != "standby" {
+		t.Errorf("RoleStandby = %v, want standby", RoleStandby)
+	}
+	if RoleUnknown != "unknown" {
+		t.Errorf("RoleUnknown = %v, want unknown", RoleUnknown)
+	}
+}
+
+func TestSyncMessageType_Constants(t *testing.T) {
+	types := []struct {
+		got  SyncMessageType
+		want string
+	}{
+		{SyncTypeFull, "full"},
+		{SyncTypeAdd, "add"},
+		{SyncTypeUpdate, "update"},
+		{SyncTypeDelete, "delete"},
+		{SyncTypeHeartbeat, "heartbeat"},
+		{SyncTypeFullRequest, "full_request"},
+	}
+
+	for _, tt := range types {
+		if string(tt.got) != tt.want {
+			t.Errorf("SyncMessageType = %v, want %v", tt.got, tt.want)
+		}
+	}
+}
+
+func TestHASyncer_BroadcastLoop_WithClient(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+	config.HeartbeatInterval = 50 * time.Millisecond
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Add a mock client
+	clientChan := make(chan *SyncMessage, 10)
+	syncer.sseClientsMu.Lock()
+	syncer.sseClients["test-client"] = clientChan
+	syncer.sseClientsMu.Unlock()
+
+	// Start broadcast loop
+	ctx, cancel := context.WithCancel(context.Background())
+	syncer.ctx = ctx
+	syncer.cancel = cancel
+
+	syncer.wg.Add(1)
+	go syncer.broadcastLoop()
+
+	// Push a change
+	session := &SessionState{
+		SessionID: "sess-001",
+		MAC:       "00:11:22:33:44:55",
+	}
+	syncer.pendingChanges <- &SyncMessage{
+		Type:     SyncTypeAdd,
+		Sessions: []SessionState{*session},
+		NodeID:   "bng-active",
+	}
+
+	// Wait for message
+	select {
+	case msg := <-clientChan:
+		if msg.Type != SyncTypeAdd {
+			t.Errorf("Type = %v, want add", msg.Type)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Timed out waiting for broadcast message")
+	}
+
+	// Wait for heartbeat
+	select {
+	case msg := <-clientChan:
+		if msg.Type != SyncTypeHeartbeat {
+			t.Errorf("Type = %v, want heartbeat", msg.Type)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Timed out waiting for heartbeat")
+	}
+
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestHASyncer_MethodNotAllowed(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-active"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Test POST to GET endpoint
+	req := httptest.NewRequest("POST", "/ha/sessions", nil)
+	w := httptest.NewRecorder()
+	syncer.handleGetSessions(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusMethodNotAllowed)
+	}
+
+	// Test POST to stream endpoint
+	req = httptest.NewRequest("POST", "/ha/sessions/stream", nil)
+	w = httptest.NewRecorder()
+	syncer.handleSessionStream(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHASyncer_IsConnected(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-test"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	// Initially not connected
+	if syncer.IsConnected() {
+		t.Error("Expected IsConnected() = false initially")
+	}
+
+	// Simulate connection
+	syncer.mu.Lock()
+	syncer.connected = true
+	syncer.mu.Unlock()
+
+	if !syncer.IsConnected() {
+		t.Error("Expected IsConnected() = true after setting connected")
+	}
+}
+
+func TestHASyncer_RecordError(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	store := newMockSessionStore()
+
+	config := DefaultSyncConfig()
+	config.NodeID = "bng-test"
+	config.Role = RoleActive
+
+	syncer := NewHASyncer(config, store, logger)
+
+	testErr := "test error message"
+	syncer.recordError(fmt.Errorf("%s", testErr))
+
+	stats := syncer.Stats()
+	if stats.LastError != testErr {
+		t.Errorf("LastError = %v, want %v", stats.LastError, testErr)
+	}
+	if stats.LastErrorTime.IsZero() {
+		t.Error("Expected LastErrorTime to be set")
+	}
+}
+
+func TestSessionState_AllFields(t *testing.T) {
+	now := time.Now()
+	session := SessionState{
+		SessionID:       "sess-001",
+		SubscriberID:    "sub-001",
+		MAC:             "00:11:22:33:44:55",
+		IP:              "10.0.0.100",
+		IPv6:            "2001:db8::100",
+		Gateway:         "10.0.0.1",
+		VLAN:            100,
+		STag:            200,
+		CTag:            300,
+		QoSProfile:      "premium",
+		DownloadRateBps: 100_000_000,
+		UploadRateBps:   50_000_000,
+		SessionType:     "ipoe",
+		ISPID:           "isp-001",
+		Username:        "user@isp.com",
+		CreatedAt:       now,
+		LastActivity:    now,
+		State:           "active",
+		WalledGarden:    false,
+		BytesIn:         1000,
+		BytesOut:        2000,
+	}
+
+	// Encode and decode to verify all fields
+	msg := &SyncMessage{
+		Type:     SyncTypeAdd,
+		Sessions: []SessionState{session},
+	}
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("Encode error: %v", err)
+	}
+
+	decoded, err := DecodeSyncMessage(data)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+
+	got := decoded.Sessions[0]
+	if got.SessionID != session.SessionID {
+		t.Errorf("SessionID mismatch")
+	}
+	if got.SubscriberID != session.SubscriberID {
+		t.Errorf("SubscriberID mismatch")
+	}
+	if got.MAC != session.MAC {
+		t.Errorf("MAC mismatch")
+	}
+	if got.IP != session.IP {
+		t.Errorf("IP mismatch")
+	}
+	if got.IPv6 != session.IPv6 {
+		t.Errorf("IPv6 mismatch")
+	}
+	if got.Gateway != session.Gateway {
+		t.Errorf("Gateway mismatch")
+	}
+	if got.VLAN != session.VLAN {
+		t.Errorf("VLAN mismatch")
+	}
+	if got.STag != session.STag {
+		t.Errorf("STag mismatch")
+	}
+	if got.CTag != session.CTag {
+		t.Errorf("CTag mismatch")
+	}
+	if got.QoSProfile != session.QoSProfile {
+		t.Errorf("QoSProfile mismatch")
+	}
+	if got.DownloadRateBps != session.DownloadRateBps {
+		t.Errorf("DownloadRateBps mismatch")
+	}
+	if got.UploadRateBps != session.UploadRateBps {
+		t.Errorf("UploadRateBps mismatch")
+	}
+	if got.SessionType != session.SessionType {
+		t.Errorf("SessionType mismatch")
+	}
+	if got.ISPID != session.ISPID {
+		t.Errorf("ISPID mismatch")
+	}
+	if got.Username != session.Username {
+		t.Errorf("Username mismatch")
+	}
+	if got.State != session.State {
+		t.Errorf("State mismatch")
+	}
+	if got.WalledGarden != session.WalledGarden {
+		t.Errorf("WalledGarden mismatch")
+	}
+	if got.BytesIn != session.BytesIn {
+		t.Errorf("BytesIn mismatch")
+	}
+	if got.BytesOut != session.BytesOut {
+		t.Errorf("BytesOut mismatch")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements peer-to-peer state synchronization between BNG HA pairs (active/standby)
- Enables standby nodes to shadow active node's subscriber session state for seamless failover
- Uses HTTP-based full sync + Server-Sent Events for incremental updates

## Components

- `pkg/ha/protocol.go`: Sync message types, session state struct, interfaces
- `pkg/ha/sync.go`: HASyncer with full sync and SSE streaming
- `pkg/ha/sync_test.go`: 20 comprehensive tests
- `pkg/agent/types.go`: HAPartner struct for bootstrap response

## Features

- Full sync on standby startup (GET /ha/sessions)
- Incremental sync via Server-Sent Events (GET /ha/sessions/stream)
- Heartbeat keepalive mechanism
- Session add/update/delete propagation
- Reconnection handling with configurable intervals
- Statistics tracking for monitoring

## Test plan

- [x] All 20 tests pass
- [x] Message encode/decode
- [x] Full sync endpoint
- [x] SSE stream processing
- [x] Integration test for full sync workflow

## Related

Part of bng-edge-infra#24 (BNG HA Implementation)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)