### PR TITLE
feat: wire unused CLI flags, HA failover, peer health, and security subsystems

### DIFF
--- a/cmd/bng/main.go
+++ b/cmd/bng/main.go
@@ -673,6 +673,9 @@ func runBNG(cmd *cobra.Command, args []string) error {
 				logger.Error("Peer pool API server error", zap.Error(err))
 			}
 		}()
+
+		// Start peer health checking
+		peerPool.Start(ctx)
 	}
 
 	// Initialize HA Syncer if configured (Demo H - active/standby with P2P sync)
@@ -1246,7 +1249,10 @@ func runBNG(cmd *cobra.Command, args []string) error {
 			logger.Warn("Failed to stop PPPoE server", zap.Error(err))
 		}
 	}
-	// Stop peer pool API server (Issue #77)
+	// Stop peer pool health checks and API server (Issue #77)
+	if peerPool != nil {
+		peerPool.Stop()
+	}
 	if peerServer != nil {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()

--- a/cmd/bng/main.go
+++ b/cmd/bng/main.go
@@ -514,6 +514,14 @@ func runBNG(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to add default pool: %w", err)
 	}
 
+	// Warn if lease mode is selected but no distributed backend is active
+	if poolMode == "lease" && nexusURL == "" && len(peerAddrs) == 0 && peerDiscovery != "dns" {
+		logger.Warn("pool-mode=lease requires Nexus or peer pool for epoch-based expiry; "+
+			"the default DHCP pool does not support epoch mode",
+			zap.String("pool_mode", poolMode),
+		)
+	}
+
 	// Create DHCP slow path server
 	dhcpServer, err := dhcp.NewServer(dhcp.ServerConfig{
 		Interface:         iface,

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.48.0
+	gopkg.in/yaml.v3 v3.0.1
 	golang.org/x/time v0.14.0
 	layeh.com/radius v0.0.0-20231213012653-1006025d24f8
 )
@@ -69,6 +70,6 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	lukechampine.com/blake3 v1.4.1 // indirect
 )

--- a/pkg/nat/manager.go
+++ b/pkg/nat/manager.go
@@ -184,6 +184,10 @@ type ManagerConfig struct {
 	PortRangeStart     int
 	PortRangeEnd       int
 
+	// Interface overrides (default to Interface if empty)
+	InsideInterface  string // Subscriber-facing interface
+	OutsideInterface string // Public-facing interface
+
 	// Feature flags
 	EnableEIM            bool // Endpoint-Independent Mapping (RFC 4787)
 	EnableEIF            bool // Endpoint-Independent Filtering

--- a/pkg/pool/peer_test.go
+++ b/pkg/pool/peer_test.go
@@ -2,6 +2,10 @@ package pool
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -227,4 +231,211 @@ func TestReleaseAllocation(t *testing.T) {
 	}
 
 	t.Logf("Original IP: %s, Reallocated IP: %s", originalIP, resp2.IP)
+}
+
+func TestRendezvousRanked(t *testing.T) {
+	nodes := []string{"node-0", "node-1", "node-2"}
+
+	ranked := rendezvousRanked("subscriber-123", nodes)
+	if len(ranked) != 3 {
+		t.Fatalf("expected 3 ranked nodes, got %d", len(ranked))
+	}
+
+	// First in ranked should equal rendezvousHash result
+	best := rendezvousHash("subscriber-123", nodes)
+	if ranked[0] != best {
+		t.Errorf("ranked[0]=%s but rendezvousHash=%s", ranked[0], best)
+	}
+
+	// All nodes should appear exactly once
+	seen := make(map[string]bool)
+	for _, n := range ranked {
+		if seen[n] {
+			t.Errorf("duplicate node in ranked: %s", n)
+		}
+		seen[n] = true
+	}
+}
+
+func TestPeerHealthTracking(t *testing.T) {
+	cfg := PeerPoolConfig{
+		NodeID:     "node-0",
+		Peers:      []string{"node-0", "node-1", "node-2"},
+		Network:    "10.0.0.0/24",
+		Gateway:    "10.0.0.1",
+		DNSServers: []string{"8.8.8.8"},
+		LeaseTime:  24 * time.Hour,
+		ListenAddr: ":8081",
+	}
+
+	pool, err := NewPeerPool(cfg)
+	if err != nil {
+		t.Fatalf("failed to create peer pool: %v", err)
+	}
+
+	// All peers should start healthy
+	if !pool.IsPeerHealthy("node-1") {
+		t.Error("node-1 should start healthy")
+	}
+	if !pool.IsPeerHealthy("node-2") {
+		t.Error("node-2 should start healthy")
+	}
+
+	// Local node is always healthy
+	if !pool.IsPeerHealthy("node-0") {
+		t.Error("local node should always be healthy")
+	}
+
+	// Unknown peer assumed healthy
+	if !pool.IsPeerHealthy("unknown-node") {
+		t.Error("unknown peer should be assumed healthy")
+	}
+
+	// Simulate failures below threshold — should stay healthy
+	pool.healthMu.Lock()
+	pool.peerHealthMap["node-1"].consecutiveFailures = 2
+	pool.healthMu.Unlock()
+
+	if !pool.IsPeerHealthy("node-1") {
+		t.Error("node-1 should still be healthy at 2 failures (threshold=3)")
+	}
+
+	// Mark unhealthy manually
+	pool.healthMu.Lock()
+	pool.peerHealthMap["node-1"].consecutiveFailures = 3
+	pool.peerHealthMap["node-1"].healthy = false
+	pool.healthMu.Unlock()
+
+	if pool.IsPeerHealthy("node-1") {
+		t.Error("node-1 should be unhealthy after 3 failures")
+	}
+}
+
+func TestGetHealthyOwnerSkipsUnhealthy(t *testing.T) {
+	cfg := PeerPoolConfig{
+		NodeID:     "node-0",
+		Peers:      []string{"node-0", "node-1", "node-2"},
+		Network:    "10.0.0.0/24",
+		Gateway:    "10.0.0.1",
+		DNSServers: []string{"8.8.8.8"},
+		LeaseTime:  24 * time.Hour,
+		ListenAddr: ":8081",
+	}
+
+	pool, err := NewPeerPool(cfg)
+	if err != nil {
+		t.Fatalf("failed to create peer pool: %v", err)
+	}
+
+	// Find a subscriber owned by a remote peer
+	var subID string
+	var primaryOwner string
+	for i := 0; i < 100; i++ {
+		sub := "subscriber-" + string(rune('a'+i))
+		owner := pool.GetOwner(sub)
+		if owner != "node-0" {
+			subID = sub
+			primaryOwner = owner
+			break
+		}
+	}
+	if subID == "" {
+		t.Skip("could not find a subscriber owned by a remote peer")
+	}
+
+	// Healthy owner should match primary
+	healthyOwner := pool.getHealthyOwner(subID)
+	if healthyOwner != primaryOwner {
+		t.Errorf("expected healthy owner %s, got %s", primaryOwner, healthyOwner)
+	}
+
+	// Mark primary owner unhealthy
+	pool.healthMu.Lock()
+	pool.peerHealthMap[primaryOwner].healthy = false
+	pool.healthMu.Unlock()
+
+	// Should now get a different owner
+	fallbackOwner := pool.getHealthyOwner(subID)
+	if fallbackOwner == primaryOwner {
+		t.Errorf("expected fallback owner different from %s", primaryOwner)
+	}
+}
+
+func TestHealthCheckWithServer(t *testing.T) {
+	// Create a mock peer HTTP server that responds to /pool/status
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/pool/status" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(PoolStats{NodeID: "peer-1"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	// Extract host:port from test server URL
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	cfg := PeerPoolConfig{
+		NodeID:     "node-0",
+		Peers:      []string{"node-0", addr},
+		Network:    "10.0.0.0/24",
+		Gateway:    "10.0.0.1",
+		DNSServers: []string{"8.8.8.8"},
+		LeaseTime:  24 * time.Hour,
+		ListenAddr: ":8081",
+	}
+
+	pool, err := NewPeerPool(cfg)
+	if err != nil {
+		t.Fatalf("failed to create peer pool: %v", err)
+	}
+
+	// Run a health check against the live mock server
+	ctx := context.Background()
+	pool.checkPeer(ctx, addr)
+
+	if !pool.IsPeerHealthy(addr) {
+		t.Error("peer with healthy server should be healthy")
+	}
+
+	// Stop the server and check again — should accumulate failures
+	server.Close()
+
+	for i := 0; i < 3; i++ {
+		pool.checkPeer(ctx, addr)
+	}
+
+	if pool.IsPeerHealthy(addr) {
+		t.Error("peer should be unhealthy after 3 failures against stopped server")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	cfg := PeerPoolConfig{
+		NodeID:     "node-0",
+		Peers:      []string{"node-0", "node-1"},
+		Network:    "10.0.0.0/24",
+		Gateway:    "10.0.0.1",
+		DNSServers: []string{"8.8.8.8"},
+		LeaseTime:  24 * time.Hour,
+		ListenAddr: ":8081",
+	}
+
+	pool, err := NewPeerPool(cfg)
+	if err != nil {
+		t.Fatalf("failed to create peer pool: %v", err)
+	}
+
+	// Use a short interval for testing
+	pool.healthInterval = 50 * time.Millisecond
+
+	ctx := context.Background()
+	pool.Start(ctx)
+
+	// Let it run a few cycles
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop should not panic or hang
+	pool.Stop()
 }


### PR DESCRIPTION
## Summary

- Wire 31 unused CLI flags to their subsystem configs (NAT44, PPPoE, Epoch, Device Auth, Resilience)
- Wire HA failover controller — automatic active/standby role switching on failure
- Add peer health monitoring — periodic health checks, skip dead peers in allocation forwarding
- Wire anti-spoofing manager — `--antispoof-mode` (disabled/strict/loose/log-only)
- Wire walled garden manager — `--walled-garden` + `--walled-garden-portal` for captive portal

## Commits (11)

1. `docs: add v0.3.0 and v0.4.0 changelog entries`
2. `feat: wire NAT44 advanced flags to manager config`
3. `feat: wire PPPoE flags and add server startup`
4. `feat: add EpochGrace to distributed allocator config`
5. `feat: wire device auth flags into Nexus HTTP client`
6. `feat: wire resilience flags and start partition manager`
7. `chore: promote gopkg.in/yaml.v3 to direct dependency`
8. `feat: wire HA failover controller into main.go`
9. `feat: add peer health monitoring to PeerPool`
10. `feat: wire anti-spoofing manager into main.go`
11. `feat: wire walled garden manager into main.go`

## New CLI flags

| Flag | Type | Default | Description |
|------|------|---------|-------------|
| `--antispoof-mode` | string | `disabled` | Anti-spoofing mode: disabled/strict/loose/log-only |
| `--walled-garden` | bool | `false` | Enable walled garden captive portal |
| `--walled-garden-portal` | string | `10.255.255.1:8080` | Portal IP:port for redirect |

## Files changed

- `cmd/bng/main.go` — All wiring (flags, startup, shutdown)
- `pkg/pool/peer.go` — Health check loop, healthy peer fallback
- `pkg/pool/peer_test.go` — 5 new tests for peer health
- `pkg/nat/manager.go` — Added InsideInterface/OutsideInterface fields
- `pkg/pppoe/server.go` — Added AuthType/SessionTimeout/MRU fields
- `pkg/allocator/distributed.go` — Added EpochGrace field
- `pkg/nexus/http_allocator.go` — Added functional option pattern

## Test plan

- [x] `go build ./cmd/bng/` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — all 33 suites pass
- [x] QA agent reviewed all commits for pattern consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)